### PR TITLE
Add header with Course Material Assistant title and sub description

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -123,9 +123,16 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem 2rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
 }
 
 header h1 {


### PR DESCRIPTION
Resolves #2

Makes the existing header element visible by updating the CSS from `display: none` to a flex column layout. The header displays "Course Materials Assistant" as the title and "Ask questions about courses, instructors, and content" as the sub description.

Generated with [Claude Code](https://claude.ai/code)